### PR TITLE
Fix test failures due to mock issues

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -669,6 +669,22 @@ pub fn create_configured_mock_database() -> MockDatabase {
     mock.expect_get_inbox_activities()
         .returning(|_, _, _| Ok(vec![]));
 
+    // Add expectations for inbox handler operations
+    mock.expect_get_note_by_id()
+        .returning(|_| Ok(None)); // Note doesn't exist, so create it
+
+    mock.expect_create_note()
+        .returning(|_| Ok(())); // Successfully create note
+
+    mock.expect_create_activity()
+        .returning(|_| Ok(())); // Successfully create activity
+
+    mock.expect_create_follow()
+        .returning(|_| Ok(())); // Successfully create follow relationship
+
+    mock.expect_update_follow_status()
+        .returning(|_, _| Ok(())); // Successfully update follow status
+
     mock
 }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -670,20 +670,15 @@ pub fn create_configured_mock_database() -> MockDatabase {
         .returning(|_, _, _| Ok(vec![]));
 
     // Add expectations for inbox handler operations
-    mock.expect_get_note_by_id()
-        .returning(|_| Ok(None)); // Note doesn't exist, so create it
+    mock.expect_get_note_by_id().returning(|_| Ok(None)); // Note doesn't exist, so create it
 
-    mock.expect_create_note()
-        .returning(|_| Ok(())); // Successfully create note
+    mock.expect_create_note().returning(|_| Ok(())); // Successfully create note
 
-    mock.expect_create_activity()
-        .returning(|_| Ok(())); // Successfully create activity
+    mock.expect_create_activity().returning(|_| Ok(())); // Successfully create activity
 
-    mock.expect_create_follow()
-        .returning(|_| Ok(())); // Successfully create follow relationship
+    mock.expect_create_follow().returning(|_| Ok(())); // Successfully create follow relationship
 
-    mock.expect_update_follow_status()
-        .returning(|_, _| Ok(())); // Successfully update follow status
+    mock.expect_update_follow_status().returning(|_, _| Ok(())); // Successfully update follow status
 
     mock
 }

--- a/tests/database_tests.rs
+++ b/tests/database_tests.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use feder8::database::{
-    create_configured_mock_database, DatabaseRef, DbActivity, DbActor, DbFollowRelation,
-    DbNote, MockDatabase,
+    create_configured_mock_database, DatabaseRef, DbActivity, DbActor, DbFollowRelation, DbNote,
+    MockDatabase,
 };
 use mockall::predicate::*;
 use serde_json::json;

--- a/tests/database_tests.rs
+++ b/tests/database_tests.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 use feder8::database::{
-    create_configured_mock_database, Database, DatabaseRef, DbActivity, DbActor, DbFollowRelation,
+    create_configured_mock_database, DatabaseRef, DbActivity, DbActor, DbFollowRelation,
     DbNote, MockDatabase,
 };
 use mockall::predicate::*;

--- a/tests/multinode_tests.rs
+++ b/tests/multinode_tests.rs
@@ -19,8 +19,10 @@ static NODE_COUNT: usize = 7;
 mod test_harness {
     use super::*;
 
+    type NodeHandles = Arc<Mutex<Vec<JoinHandle<()>>>>;
+    
     static INIT: Once = Once::new();
-    static NODES: Mutex<Option<Arc<Mutex<Vec<JoinHandle<()>>>>>> = Mutex::new(None);
+    static NODES: Mutex<Option<NodeHandles>> = Mutex::new(None);
 
     pub struct TestContext {
         pub client: Client,
@@ -124,7 +126,7 @@ mod test_harness {
             let actor_name = format!("actor{}", i + 1);
             handles.push(start_node(port, &actor_name).await);
         }
-        let nodes = Arc::new(Mutex::new(handles));
+        let nodes: NodeHandles = Arc::new(Mutex::new(handles));
         *NODES.lock().unwrap() = Some(nodes);
     }
 

--- a/tests/multinode_tests.rs
+++ b/tests/multinode_tests.rs
@@ -1,5 +1,9 @@
 use actix_web::{middleware::Logger, web, App, HttpServer};
-use feder8::{config::Config, handlers, database::{create_configured_mock_database, DatabaseRef}};
+use feder8::{
+    config::Config,
+    database::{create_configured_mock_database, DatabaseRef},
+    handlers,
+};
 use rand::Rng;
 use reqwest::Client;
 use serde_json::json;
@@ -86,7 +90,7 @@ mod test_harness {
         let server_handle = tokio::spawn(async move {
             // Initialize database (using mock for tests)
             let db: DatabaseRef = Arc::new(create_configured_mock_database());
-            
+
             let _ = HttpServer::new(move || {
                 App::new()
                     .wrap(Logger::default())

--- a/tests/multinode_tests.rs
+++ b/tests/multinode_tests.rs
@@ -1,5 +1,5 @@
 use actix_web::{middleware::Logger, web, App, HttpServer};
-use feder8::{config::Config, handlers};
+use feder8::{config::Config, handlers, database::{create_configured_mock_database, DatabaseRef}};
 use rand::Rng;
 use reqwest::Client;
 use serde_json::json;
@@ -84,10 +84,14 @@ mod test_harness {
 
         let config_clone = config.clone();
         let server_handle = tokio::spawn(async move {
+            // Initialize database (using mock for tests)
+            let db: DatabaseRef = Arc::new(create_configured_mock_database());
+            
             let _ = HttpServer::new(move || {
                 App::new()
                     .wrap(Logger::default())
                     .app_data(web::Data::new(config_clone.clone()))
+                    .app_data(web::Data::new(db.clone()))
                     .service(handlers::webfinger::webfinger)
                     .service(handlers::actor::get_actor)
                     .service(handlers::inbox::inbox)

--- a/tests/multinode_tests.rs
+++ b/tests/multinode_tests.rs
@@ -20,7 +20,7 @@ mod test_harness {
     use super::*;
 
     type NodeHandles = Arc<Mutex<Vec<JoinHandle<()>>>>;
-    
+
     static INIT: Once = Once::new();
     static NODES: Mutex<Option<NodeHandles>> = Mutex::new(None);
 


### PR DESCRIPTION
Inject mock database into multinode tests and add missing mock expectations to fix test failures.