### PR TITLE
Refactor for dependency injection

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -1,0 +1,238 @@
+use crate::config::Config;
+use crate::database::DatabaseRef;
+use crate::http::{HttpClient, ReqwestClient};
+use crate::services::delivery::DeliveryService;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Dependency injection container that manages all application dependencies
+pub struct Container {
+    config: Config,
+    database: DatabaseRef,
+    http_client: Arc<dyn HttpClient>,
+    delivery_service: Arc<DeliveryService>,
+}
+
+impl Container {
+    /// Create a new container with default implementations
+    pub fn new(config: Config, database: DatabaseRef) -> Self {
+        // Create HTTP client
+        let http_client: Arc<dyn HttpClient> = Arc::new(ReqwestClient::with_timeout(Duration::from_secs(30)));
+        
+        // Create delivery service with injected HTTP client
+        let delivery_service = Arc::new(DeliveryService::new(config.clone(), http_client.clone()));
+        
+        Self {
+            config,
+            database,
+            http_client,
+            delivery_service,
+        }
+    }
+
+    /// Create a new container with custom HTTP client
+    pub fn with_http_client(config: Config, database: DatabaseRef, http_client: Arc<dyn HttpClient>) -> Self {
+        let delivery_service = Arc::new(DeliveryService::new(config.clone(), http_client.clone()));
+        
+        Self {
+            config,
+            database,
+            http_client,
+            delivery_service,
+        }
+    }
+
+    /// Get the configuration
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
+    /// Get the database reference
+    pub fn database(&self) -> &DatabaseRef {
+        &self.database
+    }
+
+    /// Get the HTTP client
+    pub fn http_client(&self) -> &Arc<dyn HttpClient> {
+        &self.http_client
+    }
+
+    /// Get the delivery service
+    pub fn delivery_service(&self) -> &Arc<DeliveryService> {
+        &self.delivery_service
+    }
+
+    /// Create a clone of the container for use in different contexts
+    pub fn clone(&self) -> Self {
+        Self {
+            config: self.config.clone(),
+            database: self.database.clone(),
+            http_client: self.http_client.clone(),
+            delivery_service: self.delivery_service.clone(),
+        }
+    }
+}
+
+/// Builder pattern for creating containers with different configurations
+pub struct ContainerBuilder {
+    config: Option<Config>,
+    database: Option<DatabaseRef>,
+    http_client: Option<Arc<dyn HttpClient>>,
+}
+
+impl ContainerBuilder {
+    pub fn new() -> Self {
+        Self {
+            config: None,
+            database: None,
+            http_client: None,
+        }
+    }
+
+    pub fn with_config(mut self, config: Config) -> Self {
+        self.config = Some(config);
+        self
+    }
+
+    pub fn with_database(mut self, database: DatabaseRef) -> Self {
+        self.database = Some(database);
+        self
+    }
+
+    pub fn with_http_client(mut self, http_client: Arc<dyn HttpClient>) -> Self {
+        self.http_client = Some(http_client);
+        self
+    }
+
+    pub fn build(self) -> Result<Container, String> {
+        let config = self.config.ok_or("Config is required")?;
+        let database = self.database.ok_or("Database is required")?;
+        
+        match self.http_client {
+            Some(http_client) => Ok(Container::with_http_client(config, database, http_client)),
+            None => Ok(Container::new(config, database)),
+        }
+    }
+}
+
+impl Default for ContainerBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::create_configured_mock_database;
+    use crate::http::HttpClient;
+    use crate::http::{HttpRequest, HttpResponse as HttpClientResponse, StatusCode};
+    use anyhow::Result;
+    use std::collections::HashMap;
+
+    // Mock HTTP client for testing
+    struct MockHttpClient;
+
+    #[async_trait::async_trait]
+    impl HttpClient for MockHttpClient {
+        async fn send(&self, _request: HttpRequest) -> Result<HttpClientResponse> {
+            Ok(HttpClientResponse {
+                status: StatusCode(200),
+                headers: HashMap::new(),
+                body: b"OK".to_vec(),
+            })
+        }
+    }
+
+    fn create_test_config() -> Config {
+        Config {
+            server_name: "Test Server".to_string(),
+            server_url: "https://test.example.com".to_string(),
+            port: 8080,
+            actor_name: "testuser".to_string(),
+            private_key_path: None,
+            public_key_path: None,
+        }
+    }
+
+    #[test]
+    fn test_container_creation() {
+        let config = create_test_config();
+        let database = Arc::new(create_configured_mock_database());
+        let container = Container::new(config.clone(), database);
+
+        assert_eq!(container.config().server_name, config.server_name);
+        assert_eq!(container.config().server_url, config.server_url);
+        assert_eq!(container.config().port, config.port);
+        assert_eq!(container.config().actor_name, config.actor_name);
+    }
+
+    #[test]
+    fn test_container_with_custom_http_client() {
+        let config = create_test_config();
+        let database = Arc::new(create_configured_mock_database());
+        let http_client: Arc<dyn HttpClient> = Arc::new(MockHttpClient);
+        let container = Container::with_http_client(config.clone(), database, http_client);
+
+        assert_eq!(container.config().server_name, config.server_name);
+        assert_eq!(container.config().server_url, config.server_url);
+        assert_eq!(container.config().port, config.port);
+        assert_eq!(container.config().actor_name, config.actor_name);
+    }
+
+    #[test]
+    fn test_container_builder() {
+        let config = create_test_config();
+        let database = Arc::new(create_configured_mock_database());
+        let http_client: Arc<dyn HttpClient> = Arc::new(MockHttpClient);
+
+        let container = ContainerBuilder::new()
+            .with_config(config.clone())
+            .with_database(database)
+            .with_http_client(http_client)
+            .build()
+            .unwrap();
+
+        assert_eq!(container.config().server_name, config.server_name);
+        assert_eq!(container.config().server_url, config.server_url);
+        assert_eq!(container.config().port, config.port);
+        assert_eq!(container.config().actor_name, config.actor_name);
+    }
+
+    #[test]
+    fn test_container_builder_missing_config() {
+        let database = Arc::new(create_configured_mock_database());
+        
+        let result = ContainerBuilder::new()
+            .with_database(database)
+            .build();
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "Config is required");
+    }
+
+    #[test]
+    fn test_container_builder_missing_database() {
+        let config = create_test_config();
+        
+        let result = ContainerBuilder::new()
+            .with_config(config)
+            .build();
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "Database is required");
+    }
+
+    #[test]
+    fn test_container_clone() {
+        let config = create_test_config();
+        let database = Arc::new(create_configured_mock_database());
+        let container = Container::new(config.clone(), database);
+        let cloned_container = container.clone();
+
+        assert_eq!(container.config().server_name, cloned_container.config().server_name);
+        assert_eq!(container.config().server_url, cloned_container.config().server_url);
+        assert_eq!(container.config().port, cloned_container.config().port);
+        assert_eq!(container.config().actor_name, cloned_container.config().actor_name);
+    }
+}

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1,0 +1,215 @@
+use async_trait::async_trait;
+use anyhow::Result;
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// HTTP status codes
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StatusCode(pub u16);
+
+impl StatusCode {
+    pub fn is_success(&self) -> bool {
+        self.0 >= 200 && self.0 < 300
+    }
+}
+
+/// HTTP request representation
+#[derive(Debug, Clone)]
+pub struct HttpRequest {
+    pub method: String,
+    pub url: String,
+    pub headers: HashMap<String, String>,
+    pub body: Option<Vec<u8>>,
+}
+
+impl HttpRequest {
+    pub fn new(method: &str, url: &str) -> Self {
+        Self {
+            method: method.to_string(),
+            url: url.to_string(),
+            headers: HashMap::new(),
+            body: None,
+        }
+    }
+
+    pub fn with_header(mut self, name: &str, value: &str) -> Self {
+        self.headers.insert(name.to_string(), value.to_string());
+        self
+    }
+
+    pub fn with_json_body(mut self, json: &Value) -> Result<Self> {
+        self.body = Some(serde_json::to_vec(json)?);
+        self.headers.insert("content-type".to_string(), "application/json".to_string());
+        Ok(self)
+    }
+
+    pub fn with_body(mut self, body: Vec<u8>) -> Self {
+        self.body = Some(body);
+        self
+    }
+}
+
+/// HTTP response representation
+#[derive(Debug)]
+pub struct HttpResponse {
+    pub status: StatusCode,
+    pub headers: HashMap<String, String>,
+    pub body: Vec<u8>,
+}
+
+impl HttpResponse {
+    pub fn status(&self) -> StatusCode {
+        self.status
+    }
+
+    pub fn text(&self) -> Result<String> {
+        Ok(String::from_utf8(self.body.clone())?)
+    }
+
+    pub fn json<T: serde::de::DeserializeOwned>(&self) -> Result<T> {
+        Ok(serde_json::from_slice(&self.body)?)
+    }
+}
+
+/// Abstract HTTP client trait
+#[async_trait]
+pub trait HttpClient: Send + Sync {
+    /// Send an HTTP request
+    async fn send(&self, request: HttpRequest) -> Result<HttpResponse>;
+
+    /// Convenience method for GET requests
+    async fn get(&self, url: &str) -> Result<HttpResponse> {
+        self.send(HttpRequest::new("GET", url)).await
+    }
+
+    /// Convenience method for POST requests with JSON body
+    async fn post_json(&self, url: &str, json: &Value) -> Result<HttpResponse> {
+        let request = HttpRequest::new("POST", url)
+            .with_json_body(json)?;
+        self.send(request).await
+    }
+
+    /// Convenience method for POST requests with custom headers
+    async fn post_with_headers(&self, url: &str, headers: HashMap<String, String>, json: &Value) -> Result<HttpResponse> {
+        let mut request = HttpRequest::new("POST", url)
+            .with_json_body(json)?;
+        
+        for (name, value) in headers {
+            request.headers.insert(name, value);
+        }
+        
+        self.send(request).await
+    }
+}
+
+/// reqwest implementation of HttpClient
+pub mod reqwest {
+    use super::*;
+    use reqwest::Client;
+    use std::time::Duration;
+
+    pub struct ReqwestClient {
+        client: Client,
+    }
+
+    impl ReqwestClient {
+        pub fn new() -> Self {
+            Self {
+                client: Client::builder()
+                    .timeout(Duration::from_secs(30))
+                    .build()
+                    .expect("Failed to create reqwest client"),
+            }
+        }
+
+        pub fn with_timeout(timeout: Duration) -> Self {
+            Self {
+                client: Client::builder()
+                    .timeout(timeout)
+                    .build()
+                    .expect("Failed to create reqwest client"),
+            }
+        }
+    }
+
+    impl Default for ReqwestClient {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    #[async_trait]
+    impl HttpClient for ReqwestClient {
+        async fn send(&self, request: HttpRequest) -> Result<HttpResponse> {
+            let method = reqwest::Method::from_bytes(request.method.as_bytes())?;
+            let mut req_builder = self.client.request(method, &request.url);
+
+            // Add headers
+            for (name, value) in &request.headers {
+                req_builder = req_builder.header(name, value);
+            }
+
+            // Add body if present
+            if let Some(body) = request.body {
+                req_builder = req_builder.body(body);
+            }
+
+            let response = req_builder.send().await?;
+            let status = StatusCode(response.status().as_u16());
+            
+            let mut headers = HashMap::new();
+            for (name, value) in response.headers() {
+                headers.insert(
+                    name.to_string(),
+                    value.to_str().unwrap_or_default().to_string(),
+                );
+            }
+
+            let body = response.bytes().await?.to_vec();
+
+            Ok(HttpResponse {
+                status,
+                headers,
+                body,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_http_request_builder() {
+        let request = HttpRequest::new("GET", "https://example.com")
+            .with_header("Authorization", "Bearer token");
+
+        assert_eq!(request.method, "GET");
+        assert_eq!(request.url, "https://example.com");
+        assert_eq!(request.headers.get("Authorization").unwrap(), "Bearer token");
+    }
+
+    #[test]
+    fn test_http_request_with_json() {
+        let json_data = json!({"key": "value"});
+        let request = HttpRequest::new("POST", "https://example.com")
+            .with_json_body(&json_data)
+            .unwrap();
+
+        assert_eq!(request.method, "POST");
+        assert!(request.body.is_some());
+        assert_eq!(request.headers.get("content-type").unwrap(), "application/json");
+    }
+
+    #[test]
+    fn test_status_code_success() {
+        assert!(StatusCode(200).is_success());
+        assert!(StatusCode(201).is_success());
+        assert!(StatusCode(299).is_success());
+        assert!(!StatusCode(300).is_success());
+        assert!(!StatusCode(400).is_success());
+        assert!(!StatusCode(500).is_success());
+    }
+}

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -2,9 +2,13 @@ pub mod client;
 pub mod server;
 
 // Re-export the main traits for easy access
-pub use client::{HttpClient, HttpRequest, HttpResponse as ClientResponse};
-pub use server::{HttpServer, HttpHandler, HttpContext, HttpResponse as ServerResponse};
+#[allow(unused_imports)]
+pub use client::{HttpClient, HttpRequest, HttpResponse as ClientResponse, StatusCode};
+#[allow(unused_imports)]
+pub use server::{HttpContext, HttpHandler, HttpResponse as ServerResponse, HttpServer};
 
 // Re-export implementations
+#[allow(unused_imports)]
 pub use client::reqwest::ReqwestClient;
+#[allow(unused_imports)]
 pub use server::actix::ActixServer;

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,0 +1,10 @@
+pub mod client;
+pub mod server;
+
+// Re-export the main traits for easy access
+pub use client::{HttpClient, HttpRequest, HttpResponse as ClientResponse};
+pub use server::{HttpServer, HttpHandler, HttpContext, HttpResponse as ServerResponse};
+
+// Re-export implementations
+pub use client::reqwest::ReqwestClient;
+pub use server::actix::ActixServer;

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -1,0 +1,407 @@
+use async_trait::async_trait;
+use anyhow::Result;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// HTTP response for server endpoints
+#[derive(Debug)]
+pub struct HttpResponse {
+    pub status: u16,
+    pub headers: HashMap<String, String>,
+    pub body: Vec<u8>,
+}
+
+impl HttpResponse {
+    pub fn ok() -> Self {
+        Self {
+            status: 200,
+            headers: HashMap::new(),
+            body: Vec::new(),
+        }
+    }
+
+    pub fn created() -> Self {
+        Self {
+            status: 201,
+            headers: HashMap::new(),
+            body: Vec::new(),
+        }
+    }
+
+    pub fn accepted() -> Self {
+        Self {
+            status: 202,
+            headers: HashMap::new(),
+            body: Vec::new(),
+        }
+    }
+
+    pub fn not_found() -> Self {
+        Self {
+            status: 404,
+            headers: HashMap::new(),
+            body: Vec::new(),
+        }
+    }
+
+    pub fn internal_server_error() -> Self {
+        Self {
+            status: 500,
+            headers: HashMap::new(),
+            body: Vec::new(),
+        }
+    }
+
+    pub fn with_json(mut self, json: &Value) -> Result<Self> {
+        self.body = serde_json::to_vec(json)?;
+        self.headers.insert("content-type".to_string(), "application/json".to_string());
+        Ok(self)
+    }
+
+    pub fn with_activity_json(mut self, json: &Value) -> Result<Self> {
+        self.body = serde_json::to_vec(json)?;
+        self.headers.insert("content-type".to_string(), "application/activity+json".to_string());
+        Ok(self)
+    }
+
+    pub fn with_header(mut self, name: &str, value: &str) -> Self {
+        self.headers.insert(name.to_string(), value.to_string());
+        self
+    }
+
+    pub fn with_body(mut self, body: Vec<u8>) -> Self {
+        self.body = body;
+        self
+    }
+}
+
+/// HTTP request context containing request data and dependencies
+#[derive(Debug)]
+pub struct HttpContext {
+    pub method: String,
+    pub path: String,
+    pub query_params: HashMap<String, String>,
+    pub headers: HashMap<String, String>,
+    pub body: Vec<u8>,
+    pub path_params: HashMap<String, String>,
+    pub dependencies: Arc<dyn std::any::Any + Send + Sync>,
+}
+
+impl HttpContext {
+    pub fn new(method: &str, path: &str) -> Self {
+        Self {
+            method: method.to_string(),
+            path: path.to_string(),
+            query_params: HashMap::new(),
+            headers: HashMap::new(),
+            body: Vec::new(),
+            path_params: HashMap::new(),
+            dependencies: Arc::new(()),
+        }
+    }
+
+    pub fn json<T: serde::de::DeserializeOwned>(&self) -> Result<T> {
+        Ok(serde_json::from_slice(&self.body)?)
+    }
+
+    pub fn path_param(&self, name: &str) -> Option<&String> {
+        self.path_params.get(name)
+    }
+
+    pub fn query_param(&self, name: &str) -> Option<&String> {
+        self.query_params.get(name)
+    }
+
+    pub fn header(&self, name: &str) -> Option<&String> {
+        self.headers.get(name)
+    }
+
+    pub fn get_dependency<T: 'static>(&self) -> Option<&T> {
+        self.dependencies.downcast_ref::<T>()
+    }
+}
+
+/// Handler function type
+#[async_trait]
+pub trait HttpHandler: Send + Sync {
+    async fn handle(&self, context: HttpContext) -> Result<HttpResponse>;
+}
+
+/// Route definition
+#[derive(Debug, Clone)]
+pub struct Route {
+    pub method: String,
+    pub path: String,
+    pub handler_id: String,
+}
+
+impl Route {
+    pub fn new(method: &str, path: &str, handler_id: &str) -> Self {
+        Self {
+            method: method.to_string(),
+            path: path.to_string(),
+            handler_id: handler_id.to_string(),
+        }
+    }
+
+    pub fn get(path: &str, handler_id: &str) -> Self {
+        Self::new("GET", path, handler_id)
+    }
+
+    pub fn post(path: &str, handler_id: &str) -> Self {
+        Self::new("POST", path, handler_id)
+    }
+
+    pub fn put(path: &str, handler_id: &str) -> Self {
+        Self::new("PUT", path, handler_id)
+    }
+
+    pub fn delete(path: &str, handler_id: &str) -> Self {
+        Self::new("DELETE", path, handler_id)
+    }
+}
+
+/// HTTP server configuration
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+    pub host: String,
+    pub port: u16,
+    pub routes: Vec<Route>,
+}
+
+impl ServerConfig {
+    pub fn new(host: &str, port: u16) -> Self {
+        Self {
+            host: host.to_string(),
+            port,
+            routes: Vec::new(),
+        }
+    }
+
+    pub fn with_route(mut self, route: Route) -> Self {
+        self.routes.push(route);
+        self
+    }
+
+    pub fn with_routes(mut self, routes: Vec<Route>) -> Self {
+        self.routes.extend(routes);
+        self
+    }
+}
+
+/// Dependencies container for dependency injection
+pub struct Dependencies {
+    dependencies: HashMap<String, Arc<dyn std::any::Any + Send + Sync>>,
+}
+
+impl Dependencies {
+    pub fn new() -> Self {
+        Self {
+            dependencies: HashMap::new(),
+        }
+    }
+
+    pub fn insert<T: 'static + Send + Sync>(&mut self, key: &str, value: T) {
+        self.dependencies.insert(key.to_string(), Arc::new(value));
+    }
+
+    pub fn get<T: 'static>(&self, key: &str) -> Option<&T> {
+        self.dependencies.get(key)?.downcast_ref::<T>()
+    }
+
+    pub fn get_arc<T: 'static>(&self, key: &str) -> Option<Arc<T>> {
+        let any_arc = self.dependencies.get(key)?;
+        // This is a bit complex but safe way to convert Arc<dyn Any> to Arc<T>
+        let raw_ptr = Arc::as_ptr(any_arc) as *const T;
+        unsafe { Some(Arc::from_raw(raw_ptr)) }
+    }
+}
+
+impl Default for Dependencies {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Abstract HTTP server trait
+#[async_trait]
+pub trait HttpServer: Send + Sync {
+    /// Start the server with the given configuration
+    async fn start(&self, config: ServerConfig, dependencies: Dependencies) -> Result<()>;
+
+    /// Register a handler for a specific route
+    fn register_handler(&mut self, handler_id: &str, handler: Box<dyn HttpHandler>);
+}
+
+/// Actix Web implementation
+pub mod actix {
+    use super::*;
+    use actix_web::{web, App, HttpServer as ActixHttpServer, HttpRequest, HttpResponse as ActixHttpResponse};
+    use std::sync::Mutex;
+    use std::collections::HashMap;
+
+    pub struct ActixServer {
+        handlers: Arc<Mutex<HashMap<String, Box<dyn HttpHandler>>>>,
+    }
+
+    impl ActixServer {
+        pub fn new() -> Self {
+            Self {
+                handlers: Arc::new(Mutex::new(HashMap::new())),
+            }
+        }
+    }
+
+    impl Default for ActixServer {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    #[async_trait]
+    impl HttpServer for ActixServer {
+        async fn start(&self, config: ServerConfig, dependencies: Dependencies) -> Result<()> {
+            let handlers = self.handlers.clone();
+            let deps = Arc::new(dependencies);
+            
+            ActixHttpServer::new(move || {
+                let mut app = App::new();
+                
+                // Add routes
+                for route in &config.routes {
+                    let handler_id = route.handler_id.clone();
+                    let handlers_clone = handlers.clone();
+                    let deps_clone = deps.clone();
+                    
+                    app = app.route(&route.path, web::to(move |req: HttpRequest, body: web::Bytes| {
+                        let handler_id = handler_id.clone();
+                        let handlers = handlers_clone.clone();
+                        let deps = deps_clone.clone();
+                        
+                        async move {
+                            // Create context from Actix request
+                            let mut context = HttpContext::new(req.method().as_str(), req.path());
+                            context.body = body.to_vec();
+                            
+                            // Extract path parameters
+                            for (key, value) in req.match_info().iter() {
+                                context.path_params.insert(key.to_string(), value.to_string());
+                            }
+                            
+                            // Extract headers
+                            for (name, value) in req.headers() {
+                                if let Ok(value_str) = value.to_str() {
+                                    context.headers.insert(name.to_string(), value_str.to_string());
+                                }
+                            }
+                            
+                            // Extract query parameters
+                            for (key, value) in req.query_string().split('&').filter_map(|pair| {
+                                let mut parts = pair.split('=');
+                                Some((parts.next()?, parts.next()?))
+                            }) {
+                                context.query_params.insert(key.to_string(), value.to_string());
+                            }
+                            
+                            // Set dependencies
+                            context.dependencies = deps.dependencies.get("main").cloned().unwrap_or_else(|| Arc::new(()));
+                            
+                            // Get handler and execute
+                            let handlers_lock = handlers.lock().unwrap();
+                            if let Some(handler) = handlers_lock.get(&handler_id) {
+                                match handler.handle(context).await {
+                                    Ok(response) => {
+                                        let mut actix_response = ActixHttpResponse::build(
+                                            actix_web::http::StatusCode::from_u16(response.status).unwrap_or(actix_web::http::StatusCode::INTERNAL_SERVER_ERROR)
+                                        );
+                                        
+                                        for (name, value) in response.headers {
+                                            actix_response.insert_header((name, value));
+                                        }
+                                        
+                                        actix_response.body(response.body)
+                                    }
+                                    Err(e) => {
+                                        ActixHttpResponse::InternalServerError().json(serde_json::json!({
+                                            "error": e.to_string()
+                                        }))
+                                    }
+                                }
+                            } else {
+                                ActixHttpResponse::NotFound().json(serde_json::json!({
+                                    "error": "Handler not found"
+                                }))
+                            }
+                        }
+                    }));
+                }
+                
+                app
+            })
+            .bind((config.host.as_str(), config.port))?
+            .run()
+            .await?;
+            
+            Ok(())
+        }
+
+        fn register_handler(&mut self, handler_id: &str, handler: Box<dyn HttpHandler>) {
+            let mut handlers = self.handlers.lock().unwrap();
+            handlers.insert(handler_id.to_string(), handler);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_http_response_builder() {
+        let response = HttpResponse::ok()
+            .with_header("X-Custom", "value")
+            .with_json(&json!({"message": "success"}))
+            .unwrap();
+
+        assert_eq!(response.status, 200);
+        assert_eq!(response.headers.get("X-Custom").unwrap(), "value");
+        assert_eq!(response.headers.get("content-type").unwrap(), "application/json");
+    }
+
+    #[test]
+    fn test_route_builder() {
+        let route = Route::get("/users/{id}", "get_user");
+        assert_eq!(route.method, "GET");
+        assert_eq!(route.path, "/users/{id}");
+        assert_eq!(route.handler_id, "get_user");
+
+        let route = Route::post("/users", "create_user");
+        assert_eq!(route.method, "POST");
+        assert_eq!(route.path, "/users");
+        assert_eq!(route.handler_id, "create_user");
+    }
+
+    #[test]
+    fn test_server_config() {
+        let config = ServerConfig::new("localhost", 8080)
+            .with_route(Route::get("/health", "health_check"))
+            .with_route(Route::post("/users", "create_user"));
+
+        assert_eq!(config.host, "localhost");
+        assert_eq!(config.port, 8080);
+        assert_eq!(config.routes.len(), 2);
+    }
+
+    #[test]
+    fn test_dependencies() {
+        let mut deps = Dependencies::new();
+        deps.insert("config", "test_config".to_string());
+        deps.insert("port", 8080u16);
+
+        assert_eq!(deps.get::<String>("config").unwrap(), "test_config");
+        assert_eq!(deps.get::<u16>("port").unwrap(), &8080);
+        assert!(deps.get::<String>("nonexistent").is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,14 @@
 pub mod config;
+pub mod container;
 pub mod database;
 pub mod handlers;
+pub mod http;
 pub mod models;
 pub mod services;
-pub mod http;
-pub mod container;
 
 // Re-export commonly used types for easier access
 pub use config::Config;
-pub use database::{Database, DatabaseRef, MockDatabase};
-pub use models::{Actor, OrderedCollection};
-pub use http::{HttpClient, HttpServer};
 pub use container::Container;
+pub use database::{Database, DatabaseRef, MockDatabase};
+pub use http::{HttpClient, HttpServer};
+pub use models::{Actor, OrderedCollection};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,12 @@ pub mod database;
 pub mod handlers;
 pub mod models;
 pub mod services;
+pub mod http;
+pub mod container;
 
 // Re-export commonly used types for easier access
 pub use config::Config;
 pub use database::{Database, DatabaseRef, MockDatabase};
 pub use models::{Actor, OrderedCollection};
+pub use http::{HttpClient, HttpServer};
+pub use container::Container;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,12 @@ mod database;
 mod handlers;
 mod models;
 mod services;
+mod http;
+mod container;
 
 use actix_web::{middleware::Logger, web, App, HttpServer};
 use database::{create_configured_mock_database, DatabaseRef};
+use container::Container;
 use std::sync::Arc;
 
 #[actix_web::main]
@@ -23,13 +26,17 @@ async fn main() -> std::io::Result<()> {
     let db: DatabaseRef = Arc::new(create_configured_mock_database());
     tracing::info!("Database initialized (using mock)");
 
-    let config_clone = config.clone();
-    let db_clone = db.clone();
+    // Initialize dependency injection container
+    let container = Container::new(config.clone(), db);
+    tracing::info!("Dependency injection container initialized");
+
+    let container_clone = container.clone();
     HttpServer::new(move || {
         App::new()
             .wrap(Logger::default())
-            .app_data(web::Data::new(config_clone.clone()))
-            .app_data(web::Data::new(db_clone.clone()))
+            .app_data(web::Data::new(container_clone.config().clone()))
+            .app_data(web::Data::new(container_clone.database().clone()))
+            .app_data(web::Data::new(container_clone.clone()))
             .service(handlers::webfinger::webfinger)
             .service(handlers::actor::get_actor)
             .service(handlers::inbox::inbox)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,14 @@
 mod config;
+mod container;
 mod database;
 mod handlers;
+mod http;
 mod models;
 mod services;
-mod http;
-mod container;
 
 use actix_web::{middleware::Logger, web, App, HttpServer};
-use database::{create_configured_mock_database, DatabaseRef};
 use container::Container;
+use database::{create_configured_mock_database, DatabaseRef};
 use std::sync::Arc;
 
 #[actix_web::main]

--- a/src/services/delivery.rs
+++ b/src/services/delivery.rs
@@ -15,17 +15,17 @@ pub struct DeliveryService {
 #[allow(dead_code)]
 impl DeliveryService {
     pub fn new(config: Config, client: Arc<dyn HttpClient>) -> Self {
-        Self {
-            client,
-            config,
-        }
+        Self { client, config }
     }
 
     pub async fn deliver_activity(&self, inbox_url: &str, activity: Value) -> Result<()> {
         info!("Delivering activity to inbox: {}", inbox_url);
 
         let mut headers = HashMap::new();
-        headers.insert("Content-Type".to_string(), "application/activity+json".to_string());
+        headers.insert(
+            "Content-Type".to_string(),
+            "application/activity+json".to_string(),
+        );
         headers.insert(
             "User-Agent".to_string(),
             format!("Fediverse-Node/{}", env!("CARGO_PKG_VERSION")),
@@ -94,7 +94,7 @@ impl DeliveryService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::http::{HttpClient, HttpRequest, HttpResponse, StatusCode};
+    use crate::http::{ClientResponse as HttpResponse, HttpClient, HttpRequest, StatusCode};
     use serde_json::json;
     use std::sync::Arc;
 

--- a/src/services/delivery.rs
+++ b/src/services/delivery.rs
@@ -1,20 +1,22 @@
 use crate::config::Config;
+use crate::http::HttpClient;
 use anyhow::Result;
-use reqwest::Client;
 use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
 use tracing::{error, info, warn};
 
 #[allow(dead_code)]
 pub struct DeliveryService {
-    client: Client,
+    client: Arc<dyn HttpClient>,
     config: Config,
 }
 
 #[allow(dead_code)]
 impl DeliveryService {
-    pub fn new(config: Config) -> Self {
+    pub fn new(config: Config, client: Arc<dyn HttpClient>) -> Self {
         Self {
-            client: Client::new(),
+            client,
             config,
         }
     }
@@ -22,16 +24,16 @@ impl DeliveryService {
     pub async fn deliver_activity(&self, inbox_url: &str, activity: Value) -> Result<()> {
         info!("Delivering activity to inbox: {}", inbox_url);
 
+        let mut headers = HashMap::new();
+        headers.insert("Content-Type".to_string(), "application/activity+json".to_string());
+        headers.insert(
+            "User-Agent".to_string(),
+            format!("Fediverse-Node/{}", env!("CARGO_PKG_VERSION")),
+        );
+
         let response = self
             .client
-            .post(inbox_url)
-            .header("Content-Type", "application/activity+json")
-            .header(
-                "User-Agent",
-                format!("Fediverse-Node/{}", env!("CARGO_PKG_VERSION")),
-            )
-            .json(&activity)
-            .send()
+            .post_with_headers(inbox_url, headers, &activity)
             .await?;
 
         if response.status().is_success() {
@@ -40,9 +42,9 @@ impl DeliveryService {
             warn!(
                 "Failed to deliver activity to {}: {}",
                 inbox_url,
-                response.status()
+                response.status().0
             );
-            if let Ok(error_text) = response.text().await {
+            if let Ok(error_text) = response.text() {
                 error!("Error response: {}", error_text);
             }
         }
@@ -92,7 +94,39 @@ impl DeliveryService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::http::{HttpClient, HttpRequest, HttpResponse, StatusCode};
     use serde_json::json;
+    use std::sync::Arc;
+
+    // Mock HTTP client for testing
+    struct MockHttpClient {
+        should_succeed: bool,
+    }
+
+    impl MockHttpClient {
+        fn new(should_succeed: bool) -> Self {
+            Self { should_succeed }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl HttpClient for MockHttpClient {
+        async fn send(&self, _request: HttpRequest) -> Result<HttpResponse> {
+            if self.should_succeed {
+                Ok(HttpResponse {
+                    status: StatusCode(200),
+                    headers: std::collections::HashMap::new(),
+                    body: b"OK".to_vec(),
+                })
+            } else {
+                Ok(HttpResponse {
+                    status: StatusCode(500),
+                    headers: std::collections::HashMap::new(),
+                    body: b"Internal Server Error".to_vec(),
+                })
+            }
+        }
+    }
 
     fn create_test_config() -> Config {
         Config {
@@ -124,7 +158,8 @@ mod tests {
     #[test]
     fn test_delivery_service_new() {
         let config = create_test_config();
-        let service = DeliveryService::new(config.clone());
+        let client = Arc::new(MockHttpClient::new(true));
+        let service = DeliveryService::new(config.clone(), client);
 
         assert_eq!(service.config.server_name, config.server_name);
         assert_eq!(service.config.server_url, config.server_url);
@@ -152,8 +187,10 @@ mod tests {
             public_key_path: Some("/path/to/pub".to_string()),
         };
 
-        let service1 = DeliveryService::new(config1.clone());
-        let service2 = DeliveryService::new(config2.clone());
+        let client1 = Arc::new(MockHttpClient::new(true));
+        let client2 = Arc::new(MockHttpClient::new(true));
+        let service1 = DeliveryService::new(config1.clone(), client1);
+        let service2 = DeliveryService::new(config2.clone(), client2);
 
         assert_eq!(service1.config.server_name, "Server 1");
         assert_eq!(service1.config.actor_name, "alice");
@@ -169,7 +206,8 @@ mod tests {
     #[tokio::test]
     async fn test_deliver_to_followers_empty_list() {
         let config = create_test_config();
-        let service = DeliveryService::new(config);
+        let client = Arc::new(MockHttpClient::new(true));
+        let service = DeliveryService::new(config, client);
         let activity = create_test_activity();
         let followers = vec![];
 
@@ -181,7 +219,8 @@ mod tests {
     #[tokio::test]
     async fn test_deliver_to_public_empty_list() {
         let config = create_test_config();
-        let service = DeliveryService::new(config);
+        let client = Arc::new(MockHttpClient::new(true));
+        let service = DeliveryService::new(config, client);
         let activity = create_test_activity();
         let public_inboxes = vec![];
 
@@ -278,7 +317,8 @@ mod tests {
     #[test]
     fn test_delivery_service_config_persistence() {
         let original_config = create_test_config();
-        let service = DeliveryService::new(original_config.clone());
+        let client = Arc::new(MockHttpClient::new(true));
+        let service = DeliveryService::new(original_config.clone(), client);
 
         // Verify that the service maintains a copy of the config
         assert_eq!(service.config.server_name, original_config.server_name);


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Introduce dependency injection for the HTTP stack to enable swappable client and server implementations.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->